### PR TITLE
Clean up search interface elements

### DIFF
--- a/src/components/events/EventList.tsx
+++ b/src/components/events/EventList.tsx
@@ -7,18 +7,15 @@ import {
   Col,
   Card,
   Button,
-  Form,
   Badge,
   Spinner,
   Alert,
-  InputGroup,
 } from "react-bootstrap";
 import {
   Calendar,
   Users,
   MapPin,
   Plus,
-  Search,
   Wifi,
   WifiOff,
   Trophy,
@@ -137,9 +134,7 @@ const EventList: React.FC = () => {
     }));
   };
 
-  const handleSearch = (searchTerm: string) => {
-    handleFilterChange("search", searchTerm);
-  };
+  
 
   const handleEventRegister = async (event: Event) => {
     try {
@@ -261,8 +256,7 @@ const EventList: React.FC = () => {
       {/* Mobile-First Header */}
       <Row className="mb-3">
         <Col>
-          <div className="d-flex justify-content-between align-items-center mb-3">
-            <h2 className="h4 mb-0">Events</h2>
+          <div className="d-flex justify-content-end align-items-center mb-3">
             <div className="d-flex gap-2">
               {isAuthenticated && (
                 <Button variant="primary" size="sm">
@@ -272,18 +266,6 @@ const EventList: React.FC = () => {
               )}
             </div>
           </div>
-
-          {/* Search Bar */}
-          <InputGroup className="mb-3">
-            <Form.Control
-              placeholder="Search events..."
-              value={filters.search || ""}
-              onChange={(e) => handleSearch(e.target.value)}
-            />
-            <Button variant="outline-secondary">
-              <Search size={16} />
-            </Button>
-          </InputGroup>
         </Col>
       </Row>
 


### PR DESCRIPTION
Remove "Events" heading and duplicate search bar from the events page to streamline the UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-2396dfdc-b2c7-4537-ae25-c66b7c7adb99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2396dfdc-b2c7-4537-ae25-c66b7c7adb99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

