### PR TITLE
Remove document text from rules page

### DIFF
--- a/src/pages/PdfViewer.tsx
+++ b/src/pages/PdfViewer.tsx
@@ -10,12 +10,18 @@ export function PdfViewer({
     <div className={s.viewerWrap}>
       <div className={s.toolbar}></div>
       <div className={s.canvasWrap}>
-        <iframe
-          src={url}
-          title="Embedded PDF"
+        <object
+          data={url}
+          type="application/pdf"
           className={s.frame}
-          loading="lazy"
-        />
+          aria-label="PDF document"
+        >
+          <embed src={url} type="application/pdf" className={s.frame} />
+          <p>
+            Unable to display PDF.
+            <a href={url} target="_blank" rel="noopener noreferrer"> Open in a new tab</a>.
+          </p>
+        </object>
       </div>
     </div>
   );

--- a/src/pages/Rules.tsx
+++ b/src/pages/Rules.tsx
@@ -17,9 +17,7 @@ export const Rules: React.FC = () => {
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
       <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-        <label htmlFor="rules-doc-select" style={{ fontWeight: 600 }}>
-          Document
-        </label>
+        
         <select
           id="rules-doc-select"
           aria-label="Select rules document"


### PR DESCRIPTION
Remove "Document" text from the rules page and fix PDF embeds showing a blue question mark.

The previous `<iframe>` based PDF embedding was not rendering correctly, particularly in Safari and iOS, resulting in a blue square with a question mark. Switching to an `<object>` tag with an `<embed>` fallback and a direct link improves compatibility and provides a robust solution for displaying PDFs.

---
<a href="https://cursor.com/background-agent?bcId=bc-10a6d2b4-69c4-4d75-80ad-2f609ed23dbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10a6d2b4-69c4-4d75-80ad-2f609ed23dbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

