### PR TITLE
Replace rules page pdf viewer with adobe

### DIFF
--- a/src/pages/pdfViewer.css.ts
+++ b/src/pages/pdfViewer.css.ts
@@ -32,3 +32,12 @@ export const frame = style({
   border: "none",
   display: "block",
 });
+
+// Adobe PDF Embed container styling
+export const embedContainer = style({
+  width: "100%",
+  height: "80vh",
+  border: "none",
+  display: "block",
+  background: "#1a1a1a",
+});

--- a/src/types/adobe-embed.d.ts
+++ b/src/types/adobe-embed.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  interface Window {
+    AdobeDC?: any;
+    __adobeViewSDKReady?: () => void;
+  }
+}
+
+export {};
+


### PR DESCRIPTION
Replace the existing PDF viewer with Adobe's PDF Embed API to fix the non-functional viewer and improve reliability.

The previous `pdfjs-dist` based viewer was reported as not working. This PR integrates Adobe's PDF Embed API, an industry standard, to provide a more stable and consistent viewing experience. It also includes a robust iframe fallback if the Adobe SDK fails to load or the client ID is not configured.

---
<a href="https://cursor.com/background-agent?bcId=bc-81cb0066-a604-4c27-82d8-1c232ac9c892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-81cb0066-a604-4c27-82d8-1c232ac9c892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

