### PR TITLE
Fix pdf loading on rules page

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -73,6 +73,17 @@ self.addEventListener("fetch", (event) => {
     return;
   }
 
+  // Bypass Service Worker for PDFs and Range requests to preserve native streaming/viewers
+  try {
+    const isRange = request.headers.get("Range") != null;
+    if (isPdfRequest(request) || isRange) {
+      event.respondWith(fetch(request));
+      return;
+    }
+  } catch (_) {
+    // no-op
+  }
+
   // Handle different types of requests
   if (request.url.includes("/api/")) {
     // API requests - Network First with Cache Fallback


### PR DESCRIPTION
Bypass service worker for PDF and Range requests to fix PDFs not loading on the rules page.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef758a2f-8c35-4442-bab1-d4b9df8d1386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef758a2f-8c35-4442-bab1-d4b9df8d1386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

