### PR TITLE
Keep home button appearance consistent on click

### DIFF
--- a/src/components/BubbleMenu.tsx
+++ b/src/components/BubbleMenu.tsx
@@ -359,10 +359,12 @@ export const BubbleMenu: React.FC<BubbleMenuProps> = ({
                 <button
                   key={item.id}
                   className={`${bm.menuItem} ${
-                    currentPage === item.id 
-                      ? item.id === "home" 
-                        ? bm.menuItemHomeActive 
-                        : bm.menuItemActive 
+                    item.id === "home" ? bm.menuItemHome : ""
+                  } ${
+                    currentPage === item.id
+                      ? item.id === "home"
+                        ? bm.menuItemHomeActive
+                        : bm.menuItemActive
                       : ""
                   }`}
                   onClick={() => {

--- a/src/components/bubbleMenu.css.ts
+++ b/src/components/bubbleMenu.css.ts
@@ -136,6 +136,12 @@ export const menuItemHomeActive = style({
   borderColor: "black",
   boxShadow: "0 6px 20px rgba(0,0,0,0.2)",
 });
+// Prevent visual change on press for the Home menu item
+export const menuItemHome = style({
+  selectors: {
+    "&:active": { background: "rgba(255,255,255,0.02)", color: "var(--text-primary)" },
+  },
+});
 export const menuLabel = style({ fontWeight: 500 });
 
 // User panel styles


### PR DESCRIPTION
Stop the 'Home' button in the bubble menu from changing visually when clicked.

---
<a href="https://cursor.com/background-agent?bcId=bc-2acd2bee-b1d6-420a-9b92-e6684e166fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2acd2bee-b1d6-420a-9b92-e6684e166fb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

