### PR TITLE
Keep home button opaque on click

### DIFF
--- a/src/components/bubbleMenu.css.ts
+++ b/src/components/bubbleMenu.css.ts
@@ -139,7 +139,9 @@ export const menuItemHomeActive = style({
 // Prevent visual change on press for the Home menu item
 export const menuItemHome = style({
   selectors: {
-    "&:active": { background: "rgba(255,255,255,0.02)", color: "var(--text-primary)" },
+		"&:hover": { background: "rgba(255,255,255,0.02)", color: "var(--text-primary)" },
+		"&:active": { background: "rgba(255,255,255,0.02)", color: "var(--text-primary)" },
+		"&:hover:active": { background: "rgba(255,255,255,0.02)", color: "var(--text-primary)" },
   },
 });
 export const menuLabel = style({ fontWeight: 500 });

--- a/src/mobile/mobileNav.css.ts
+++ b/src/mobile/mobileNav.css.ts
@@ -62,7 +62,8 @@ export const tabHome = style({
   background: "#fff",
   selectors: {
     "&:hover": { background: "#fff", color: "#000" },
-    "&:active": { background: "#fff", color: "#000" },
+		"&:active": { background: "#fff", color: "#000" },
+		"&:hover:active": { background: "#fff", color: "#000" },
   },
 });
 


### PR DESCRIPTION
Prevent the Home button from changing appearance on click in both desktop and mobile navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-04fc3286-03be-44a2-8890-498fcca0203f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-04fc3286-03be-44a2-8890-498fcca0203f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

