### PR TITLE
Diagnose website black screen issue

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import * as ReactDOM from "react-dom";
-import App from "./App.tsx";
+import { createRoot } from "react-dom/client";
+import App from "./App";
 import "./global.css.ts";
 import { getBasePath } from "./utils/basePath";
 
@@ -52,18 +52,8 @@ if ("serviceWorker" in navigator) {
 }
 
 const rootEl = document.getElementById("root")!;
-const anyReactDOM = ReactDOM as any;
-if (typeof anyReactDOM.createRoot === "function") {
-  anyReactDOM.createRoot(rootEl).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>,
-  );
-} else if (typeof anyReactDOM.render === "function") {
-  anyReactDOM.render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>,
-    rootEl,
-  );
-}
+createRoot(rootEl).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);


### PR DESCRIPTION
Update React rendering to use `createRoot` from `react-dom/client` to resolve a black screen issue due to React 18/19 incompatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-ef50dedd-a6a1-40ee-afe9-c7b9708f5afe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ef50dedd-a6a1-40ee-afe9-c7b9708f5afe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

