### PR TITLE
Adjust menu button height to text

### DIFF
--- a/src/global.css.ts
+++ b/src/global.css.ts
@@ -571,6 +571,17 @@ globalStyle("*", {
 });
 // Larger tap area is opt-in via .btn-touch; .btn should size to its text
 globalStyle(".btn", { lineHeight: 1 });
+// Ensure all native buttons have no vertical padding so height equals text height
+globalStyle("button", {
+  paddingTop: "0 !important",
+  paddingBottom: "0 !important",
+  lineHeight: 1,
+});
+// Preserve larger tap targets for .btn-touch
+globalStyle(".btn-touch", {
+  paddingTop: "0.75rem !important",
+  paddingBottom: "0.75rem !important",
+});
 // High contrast mode tweaks
 globalStyle('[data-contrast="high"]', {
   vars: { "--border-color": "#888" },

--- a/src/mobile/mobileNav.css.ts
+++ b/src/mobile/mobileNav.css.ts
@@ -27,7 +27,8 @@ export const navInner = style({
 });
 
 export const tab = style({
-  padding: "10px 0 8px",
+  // Horizontal padding only to size to text
+  padding: "0 0",
   display: "flex",
   flexDirection: "column",
   alignItems: "center",

--- a/src/pages/CompanionPage.tsx
+++ b/src/pages/CompanionPage.tsx
@@ -82,7 +82,8 @@ export const CompanionPage: React.FC<CompanionPageProps> = () => {
           
           .tab-button {
             flex: 1;
-            padding: 1rem;
+            /* Remove vertical padding to size to text */
+            padding: 0 1rem;
             background: #fff;
             border: none;
             color: #000;
@@ -91,6 +92,7 @@ export const CompanionPage: React.FC<CompanionPageProps> = () => {
             font-weight: 500;
             transition: all 0.3s ease;
             border-bottom: 3px solid transparent;
+            line-height: 1;
           }
           
           .tab-button:hover {

--- a/src/pages/events.css.ts
+++ b/src/pages/events.css.ts
@@ -25,9 +25,11 @@ globalStyle(`${navTabs} > button`, {
   color: "#000",
   border: "1px solid #000",
   borderRadius: 8,
-  padding: "0.5rem 1rem",
+  // Horizontal padding only so height equals text height
+  padding: "0 1rem",
   cursor: "pointer",
   transition: "all 0.2s ease",
+  lineHeight: 1,
 });
 globalStyle(`${navTabs} > button.active`, {
   background: "#000",
@@ -80,9 +82,10 @@ globalStyle(`${viewSelector} > button`, {
   color: "#000",
   border: "1px solid #000",
   borderRadius: 8,
-  padding: "0.5rem 1rem",
+  padding: "0 1rem",
   cursor: "pointer",
   transition: "all 0.2s ease",
+  lineHeight: 1,
 });
 globalStyle(`${viewSelector} > button.active`, {
   background: "#000",

--- a/src/pages/tournamentHub.css.ts
+++ b/src/pages/tournamentHub.css.ts
@@ -8,7 +8,8 @@ export const tabs = style({
   marginBottom: 12,
 });
 export const tab = style({
-  padding: "8px 6px",
+  // Remove vertical padding so height matches text
+  padding: "0 6px",
   textAlign: "center",
   border: "1px solid rgba(255,255,255,0.08)",
   borderRadius: 8,


### PR DESCRIPTION
Ensure all buttons' height matches their text by removing vertical padding and setting `line-height: 1`.

---
<a href="https://cursor.com/background-agent?bcId=bc-018b21e4-7e9a-4a0c-b41b-fc9025fa3eec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-018b21e4-7e9a-4a0c-b41b-fc9025fa3eec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

